### PR TITLE
Add technical indicator utilities

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -56,6 +56,21 @@ Use the included `backend/config.yaml` as a starting point and adjust values for
     - Data provider plugin
     - Trading parameters
     - Risk management rules
+    - Technical indicator parameters
+
+### Technical Indicators
+The `config.yaml` file includes defaults for several indicators used by the
+analysis plugins:
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `rsi_period` | Lookback period for RSI calculations | 14 |
+| `rsi_overbought` | RSI level considered overbought | 70 |
+| `rsi_oversold` | RSI level considered oversold | 30 |
+| `ema_fast` | Fast EMA period for MACD | 9 |
+| `ema_slow` | Slow EMA period for MACD | 21 |
+| `iv_percentile_period` | Days used to compute IV percentile | 252 |
+| `high_vol_threshold` | Percentile marking high volatility | 0.75 |
 
 ## Testing
 ```bash

--- a/backend/core/orchestrator.py
+++ b/backend/core/orchestrator.py
@@ -17,6 +17,7 @@ class PluginOrchestrator:
         plugin_map = {
             "data": f"plugins.data.{settings.data_plugin}",
             "signals": "plugins.analysis.composite_signals",
+            "technical": "plugins.analysis.technical",
             "selector": "plugins.trading.spread_selector",
             "risk": "plugins.risk.portfolio_manager",
             "executor": f"plugins.execution.{settings.broker_plugin}"

--- a/backend/plugins/analysis/technical.py
+++ b/backend/plugins/analysis/technical.py
@@ -1,0 +1,87 @@
+import asyncio
+from typing import Dict
+
+import pandas as pd
+
+from plugins.base import PluginInterface
+
+
+def compute_ema(series: pd.Series, period: int) -> pd.Series:
+    """Compute Exponential Moving Average."""
+    return series.ewm(span=period, adjust=False).mean()
+
+
+def compute_rsi(series: pd.Series, period: int = 14) -> pd.Series:
+    """Compute Relative Strength Index."""
+    delta = series.diff()
+    gain = delta.clip(lower=0)
+    loss = -delta.clip(upper=0)
+
+    avg_gain = gain.rolling(window=period, min_periods=period).mean()
+    avg_loss = loss.rolling(window=period, min_periods=period).mean()
+    rs = avg_gain / avg_loss
+    rsi = 100 - (100 / (1 + rs))
+    rsi = rsi.fillna(0)
+    rsi[avg_loss == 0] = 100
+    return rsi
+
+
+def compute_macd(series: pd.Series, fast: int = 12, slow: int = 26, signal: int = 9) -> pd.DataFrame:
+    """Compute Moving Average Convergence Divergence."""
+    ema_fast = compute_ema(series, fast)
+    ema_slow = compute_ema(series, slow)
+    macd_line = ema_fast - ema_slow
+    signal_line = compute_ema(macd_line, signal)
+    histogram = macd_line - signal_line
+    return pd.DataFrame({"macd": macd_line, "signal": signal_line, "hist": histogram})
+
+
+def compute_atr(df: pd.DataFrame, period: int = 14) -> pd.Series:
+    """Compute Average True Range."""
+    high = df["high"]
+    low = df["low"]
+    close = df["close"]
+    prev_close = close.shift(1)
+
+    tr = pd.concat([
+        (high - low),
+        (high - prev_close).abs(),
+        (low - prev_close).abs(),
+    ], axis=1).max(axis=1)
+    atr = tr.rolling(window=period, min_periods=period).mean()
+    return atr
+
+
+def determine_volatility_regime(atr_series: pd.Series, threshold: float = 0.75) -> str:
+    """Classify volatility regime based on ATR percentile."""
+    percentile = atr_series.rank(pct=True).iloc[-1]
+    return "HIGH_VOLATILITY" if percentile >= threshold else "NORMAL_VOLATILITY"
+
+
+class TechnicalPlugin(PluginInterface):
+    """Plugin exposing technical indicator calculations."""
+
+    async def _setup(self) -> None:
+        await asyncio.sleep(0)
+
+    async def execute(self, price_data: pd.DataFrame | None = None) -> Dict[str, float]:
+        if price_data is None or price_data.empty:
+            return {}
+        close = price_data["close"]
+        rsi_series = compute_rsi(close, self.config.get("rsi_period", 14))
+        macd_df = compute_macd(
+            close,
+            self.config.get("ema_fast", 12),
+            self.config.get("ema_slow", 26),
+        )
+        atr_series = compute_atr(price_data[["high", "low", "close"]])
+        regime = determine_volatility_regime(atr_series, self.config.get("high_vol_threshold", 0.75))
+        return {
+            "rsi": float(rsi_series.iloc[-1]),
+            "macd": float(macd_df["macd"].iloc[-1]),
+            "signal": float(macd_df["signal"].iloc[-1]),
+            "ema": float(compute_ema(close, self.config.get("ema_fast", 12)).iloc[-1]),
+            "atr": float(atr_series.iloc[-1]),
+            "regime": regime,
+        }
+

--- a/backend/tests/test_technical.py
+++ b/backend/tests/test_technical.py
@@ -1,0 +1,20 @@
+import pandas as pd
+
+from plugins.analysis.technical import compute_rsi, determine_volatility_regime, compute_atr
+
+
+def test_compute_rsi_uptrend():
+    prices = pd.Series(range(1, 16))  # Strictly increasing
+    rsi = compute_rsi(prices, period=14)
+    assert round(rsi.iloc[-1], 2) == 100.0
+
+
+def test_volatility_regime_detection():
+    data = pd.DataFrame({
+        "high": [1, 2, 3, 4, 5],
+        "low": [0.5, 1, 2, 3, 4],
+        "close": [0.8, 1.5, 2.5, 3.5, 4.5],
+    })
+    atr = compute_atr(data, period=3)
+    regime = determine_volatility_regime(atr, threshold=0.6)
+    assert regime == "HIGH_VOLATILITY"


### PR DESCRIPTION
## Summary
- implement technical analysis plugin with RSI, MACD, EMA, ATR and regime detection
- load the new plugin via `PluginOrchestrator`
- test RSI calculation and volatility regime logic
- document indicator settings in backend README

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684963e1baac832fb37304e1603b9183