### PR TITLE
Implement DB metrics

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -24,6 +24,12 @@ pip install -r requirements.txt
 # Copy environment variables
 cp .env.example .env
 
+### Database Setup
+The dashboard metrics endpoint reads from the configured database. Ensure the
+database specified by `DATABASE_URL` is running before starting the server.
+Tables are created automatically on startup. For local testing you can set
+`DATABASE_URL=sqlite:///./test.db` to use SQLite.
+
 # Start the server
 ./scripts/start.sh
 # Or directly: uvicorn api.main:app --reload


### PR DESCRIPTION
## Summary
- fetch dashboard metrics from the database instead of returning constants
- wire up a SQLite database in tests
- update example test cases for new metrics
- document database setup in the backend README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684968747d90832fb701ca3dd200775b